### PR TITLE
feat(InvestmentDetails): current investors #11 #12

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+export PATH="/Users/svpervnder/.local/share/solana/install/active_release/bin:/Users/svpervnder/.yarn/bin:/Users/svpervnder/.config/yarn/global/node_modules/.bin:/Users/svpervnder/Library/Android/sdk/platform-tools:/Users/svpervnder/.nvm/versions/node/v14.16.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin:/Users/svpervnder/.cargo/bin:/Users/svpervnder/go:/Users/svpervnder/flutter/bin:/Users/svpervnder/bin"
+
 yarn lint-staged

--- a/app/src/app/property-details/investment-details/InvestmentDetails.module.scss
+++ b/app/src/app/property-details/investment-details/InvestmentDetails.module.scss
@@ -38,4 +38,10 @@
       margin-bottom: 0;
     }
   }
+
+  &__clickable {
+    &:hover {
+      cursor: pointer;
+    }
+  }
 }

--- a/app/src/app/property-details/investment-details/InvestmentDetails.module.scss.d.ts
+++ b/app/src/app/property-details/investment-details/InvestmentDetails.module.scss.d.ts
@@ -1,5 +1,6 @@
 export type Styles = {
   "investment-details__circular-progress": string;
+  "investment-details__clickable": string;
   "investment-details__heading": string;
   "investment-details__heading2": string;
   "investment-details__price": string;

--- a/app/src/app/property-details/investment-details/InvestmentDetails.tsx
+++ b/app/src/app/property-details/investment-details/InvestmentDetails.tsx
@@ -72,7 +72,7 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
   });
 
   useEffect(() => {
-    if (!contract || !wallet.isConnected) {
+    if (!contract) {
       setValues(getDefaultContractValues());
 
       return;
@@ -85,7 +85,7 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
 
       const deposits = await contract!.get_deposits();
       const expirationDate = await contract!.get_expiration_date();
-      const depositsOfResponse = await contract!.deposits_of({ payee: wallet.address! });
+      const depositsOfResponse = await contract!.deposits_of({ payee: wallet.address ?? wallet.context.guest.address });
 
       const currentCoinPrice = await getCoinCurrentPrice("near", "usd");
       const priceEquivalence =
@@ -105,7 +105,7 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
     };
 
     getConstantValues();
-  }, [contract, wallet.address, wallet.isConnected]);
+  }, [contract, wallet.address, wallet.context.guest.address]);
 
   const onClickAuthorizeWallet = () => {
     wallet.onClickConnect({

--- a/app/src/app/property-details/investment-details/InvestmentDetails.tsx
+++ b/app/src/app/property-details/investment-details/InvestmentDetails.tsx
@@ -40,6 +40,7 @@ const getDefaultContractValues = (): ConditionalEscrowValues => ({
   totalFunds: near.formatAccountBalance("0"),
   minFundingAmount: near.formatAccountBalance("0"),
   depositsOf: near.formatAccountBalance("0"),
+  depositsOfPercentage: 0,
   currentCoinPrice: 0,
   priceEquivalence: 0,
   totalFundedPercentage: 0,
@@ -81,11 +82,12 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
     const getConstantValues = async () => {
       const getTotalFundsResponse = await contract!.get_total_funds();
       const getMinFundingAmountResponse = await contract!.get_min_funding_amount();
-      const totalFundedPercentage = BigInt(getMinFundingAmountResponse) / BigInt(getTotalFundsResponse);
+      const totalFundedPercentage = (BigInt(getTotalFundsResponse) * BigInt(100)) / BigInt(getMinFundingAmountResponse);
 
       const deposits = await contract!.get_deposits();
       const expirationDate = await contract!.get_expiration_date();
       const depositsOfResponse = await contract!.deposits_of({ payee: wallet.address ?? wallet.context.guest.address });
+      const depositsOfPercentage = (BigInt(depositsOfResponse) * BigInt(100)) / BigInt(getMinFundingAmountResponse);
 
       const currentCoinPrice = await getCoinCurrentPrice("near", "usd");
       const priceEquivalence =
@@ -97,6 +99,7 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
         minFundingAmount: near.formatAccountBalance(BigInt(getMinFundingAmountResponse).toString()),
         depositsOf: near.formatAccountBalance(BigInt(depositsOfResponse).toString()),
         totalFundedPercentage: Number(totalFundedPercentage),
+        depositsOfPercentage: Number(depositsOfPercentage),
         currentCoinPrice,
         priceEquivalence,
         deposits,
@@ -182,7 +185,8 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
               <Typography.MiniDescription>See withdrawal conditions</Typography.MiniDescription>
             </Grid.Col>
             <Grid.Col>
-              <Typography.Text>{values.depositsOf}</Typography.Text>
+              <Typography.Text flat>{values.depositsOf}</Typography.Text>
+              <Typography.MiniDescription>{`${values.depositsOfPercentage}% of property price`}</Typography.MiniDescription>
             </Grid.Col>
           </Grid.Row>
           <Grid.Row>

--- a/app/src/app/property-details/investment-details/InvestmentDetails.tsx
+++ b/app/src/app/property-details/investment-details/InvestmentDetails.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
-import moment from "moment";
 
 import { Card } from "ui/card/Card";
 import { Modal } from "ui/modal/Modal";
@@ -14,6 +13,7 @@ import near from "providers/near";
 import { ContractDepositFormProps } from "../contract-deposit-form/ContractDepositForm.types";
 import getCoinCurrentPrice from "providers/currency/getCoinCurrentPrice";
 import formatFiatCurrency from "providers/currency/formatFiatCurrency";
+import date from "providers/date";
 
 import styles from "./InvestmentDetails.module.scss";
 import { ConditionalEscrowValues, InvestmentDetailsProps, OnSubmitDeposit } from "./InvestmentDetails.types";
@@ -43,7 +43,7 @@ const getDefaultContractValues = (): ConditionalEscrowValues => ({
   currentCoinPrice: 0,
   priceEquivalence: 0,
   totalFundedPercentage: 0,
-  expirationDate: undefined,
+  expirationDate: date.toNanoseconds(date.now().toDate().getTime()),
   recipientAccountId: undefined,
   isDepositAllowed: false,
   isWithdrawalAllowed: false,
@@ -100,17 +100,7 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
         currentCoinPrice,
         priceEquivalence,
         deposits,
-        expirationDate: (
-          <Typography.Description>
-            Offer expires
-            <br />
-            {moment(expirationDate / 1000000)
-              .utcOffset(0)
-              .calendar()
-              .toLowerCase()}
-            , GMT-0
-          </Typography.Description>
-        ),
+        expirationDate,
       });
     };
 
@@ -154,7 +144,12 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
             <div className={styles["investment-details__sold-description"]}>
               <Typography.Description>Funded</Typography.Description>
               <Typography.Text flat>{values.totalFunds}</Typography.Text>
-              <Typography.MiniDescription>{`${values.totalFundedPercentage}% of property price`}</Typography.MiniDescription>
+              <Typography.MiniDescription>
+                {`${values.totalFundedPercentage}% of property price`} ·{" "}
+                {`${date.timeFromNow
+                  .asDefault(date.fromNanoseconds(values.expirationDate!), true)
+                  .toLowerCase()} remaining`}
+              </Typography.MiniDescription>
             </div>
           </div>
           <div className={styles["investment-details__price"]}>
@@ -222,7 +217,11 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
           ) : (
             <>
               <Button onClick={onClickInvestNow}>Invest Now</Button>
-              {values.expirationDate}
+              <Typography.Description>
+                Offer expires
+                <br />
+                {date.timeFromNow.calendar(date.fromNanoseconds(values.expirationDate!)).toLowerCase()}
+              </Typography.Description>
             </>
           )}
         </Card.Actions>

--- a/app/src/app/property-details/investment-details/InvestmentDetails.tsx
+++ b/app/src/app/property-details/investment-details/InvestmentDetails.tsx
@@ -55,6 +55,7 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
   // @TODO display an error toast
   const [, setError] = useState<string | undefined>(undefined);
   const [isBuyOwnershipInfoModalOpen, setIsBuyOwnershipInfoModalOpen] = useState(false);
+  const [isCurrentInvestorsModalOpen, setIsCurrentInvestorsModalOpen] = useState(false);
 
   const [values, setValues] = useState<ConditionalEscrowValues>(getDefaultContractValues());
 
@@ -173,7 +174,12 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
           <Grid.Row>
             <Grid.Col lg={6}>
               <Typography.TextBold flat># of NEAR wallets</Typography.TextBold>
-              <Typography.MiniDescription>See current investors</Typography.MiniDescription>
+              <Typography.MiniDescription
+                onClick={() => setIsCurrentInvestorsModalOpen(true)}
+                className={styles["investment-details__clickable"]}
+              >
+                See current investors
+              </Typography.MiniDescription>
             </Grid.Col>
             <Grid.Col>
               <Typography.Text>{values.deposits?.length}</Typography.Text>
@@ -232,7 +238,7 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
       </Card>
 
       {isBuyOwnershipInfoModalOpen && (
-        <Modal isOpened onClose={() => null} aria-labelledby="Register Interest Modal Window">
+        <Modal isOpened onClose={() => null} aria-labelledby="Buy Ownership Modal Window">
           <Modal.Header>
             <Typography.Headline3 className={styles["investment-details__register-interest-modal--header"]}>
               Buy Property Ownership
@@ -256,6 +262,32 @@ export const InvestmentDetails: React.FC<InvestmentDetailsProps> = ({ contractAd
               autoFocus
               onCancel={() => setIsBuyOwnershipInfoModalOpen(false)}
             />
+          </Modal.Actions>
+        </Modal>
+      )}
+
+      {isCurrentInvestorsModalOpen && (
+        <Modal isOpened onClose={() => null} aria-labelledby="Current Investors Modal Window">
+          <Modal.Header>
+            <Typography.Headline3 className={styles["investment-details__register-interest-modal--header"]}>
+              Current Investors
+            </Typography.Headline3>
+          </Modal.Header>
+          <Modal.Content>
+            {values.deposits?.length &&
+              values.deposits?.map((deposit) => (
+                <Grid.Row key={deposit[0]}>
+                  <Grid.Col>
+                    <Typography.Text>{deposit[0]}</Typography.Text>
+                  </Grid.Col>
+                  <Grid.Col>
+                    <Typography.Text>{near.formatAccountBalance(BigInt(deposit[1]).toString())}</Typography.Text>
+                  </Grid.Col>
+                </Grid.Row>
+              ))}
+          </Modal.Content>
+          <Modal.Actions>
+            <Button onClick={() => setIsCurrentInvestorsModalOpen(false)}>Close</Button>
           </Modal.Actions>
         </Modal>
       )}

--- a/app/src/app/property-details/investment-details/InvestmentDetails.types.ts
+++ b/app/src/app/property-details/investment-details/InvestmentDetails.types.ts
@@ -16,7 +16,7 @@ export type ConditionalEscrowValues = {
   totalFundedPercentage?: number;
   currentCoinPrice?: number;
   priceEquivalence?: number;
-  expirationDate?: JSX.Element;
+  expirationDate?: number;
   recipientAccountId?: string;
   isDepositAllowed?: boolean;
   isWithdrawalAllowed?: boolean;

--- a/app/src/app/property-details/investment-details/InvestmentDetails.types.ts
+++ b/app/src/app/property-details/investment-details/InvestmentDetails.types.ts
@@ -22,4 +22,5 @@ export type ConditionalEscrowValues = {
   isWithdrawalAllowed?: boolean;
   deposits?: string[][];
   depositsOf?: string;
+  depositsOfPercentage?: number;
 };

--- a/app/src/context/near-wallet/NearWalletContextController.tsx
+++ b/app/src/context/near-wallet/NearWalletContextController.tsx
@@ -10,6 +10,8 @@ import getConfig from "providers/near/getConfig";
 import { NEARSignInOptions, NearWalletContextControllerProps } from "./NearWalletContext.types";
 
 const DEFAULT_NETWORK_ENV = "testnet";
+const GUEST_WALLET_ID_TESTNET = "escrowfactory.testnet";
+const GUEST_WALLET_ID_MAINNET = "escrowfactory.near";
 
 export const NearWalletContextController = ({ children }: NearWalletContextControllerProps) => {
   const walletState = useWalletState();
@@ -84,7 +86,13 @@ export const NearWalletContextController = ({ children }: NearWalletContextContr
     address: walletState.address.get(),
     balance: walletState.balance.get(),
     onSetChain,
-    context: { connection: walletConnection?.wallet },
+    context: {
+      connection: walletConnection?.wallet,
+      provider: walletConnection?.near,
+      guest: {
+        address: walletState.network.get() === "testnet" ? GUEST_WALLET_ID_TESTNET : GUEST_WALLET_ID_MAINNET,
+      },
+    },
   };
 
   return <WalletSelectorContextController {...props}>{children}</WalletSelectorContextController>;

--- a/app/src/context/wallet-selector/WalletSelectorContext.types.ts
+++ b/app/src/context/wallet-selector/WalletSelectorContext.types.ts
@@ -1,4 +1,4 @@
-import { WalletConnection as NEARWalletConnection } from "near-api-js";
+import { Near, WalletConnection as NEARWalletConnection } from "near-api-js";
 import { ReactNode } from "react";
 
 import { NEARSignInOptions } from "context/near-wallet/NearWalletContext.types";
@@ -22,5 +22,7 @@ export type WalletSelectorContextType = {
   onClickConnect: (args?: NEARSignInOptions) => void;
   context: {
     connection: NEARWalletConnection | undefined;
+    provider: Near | undefined;
+    guest: { address: string };
   };
 };

--- a/app/src/providers/date/getDefaultDateFormat.ts
+++ b/app/src/providers/date/getDefaultDateFormat.ts
@@ -1,3 +1,8 @@
 import moment from "moment";
 
+export const now = () => moment();
+
+export const toNanoseconds = (date: number) => date * 1000000;
+export const fromNanoseconds = (date: number) => date / 1000000;
+
 export default (date?: Date | string | number) => moment(date || undefined).format("MMM DD, YYYY");

--- a/app/src/providers/date/index.ts
+++ b/app/src/providers/date/index.ts
@@ -1,0 +1,10 @@
+import timeFromNow from "./timeFromNow";
+import getDefaultDateFormat, { toNanoseconds, now, fromNanoseconds } from "./getDefaultDateFormat";
+
+export default {
+  timeFromNow,
+  getDefaultDateFormat,
+  toNanoseconds,
+  fromNanoseconds,
+  now,
+};

--- a/app/src/providers/date/timeFromNow.ts
+++ b/app/src/providers/date/timeFromNow.ts
@@ -1,0 +1,11 @@
+import moment from "moment";
+
+export const asDefault = (date?: Date | string | number, withoutSuffix?: boolean) =>
+  moment(date).fromNow(withoutSuffix);
+
+export const calendar = (date?: Date | string | number) => moment(date).calendar();
+
+export default {
+  asDefault,
+  calendar,
+};

--- a/app/src/providers/near/contract.ts
+++ b/app/src/providers/near/contract.ts
@@ -1,9 +1,9 @@
 import * as nearAPI from "near-api-js";
-import { ConnectedWalletAccount, Contract } from "near-api-js";
+import { Account, Contract } from "near-api-js";
 import { ContractMethods } from "near-api-js/lib/contract";
 
 export function initConditionalEscrowContract<M>(
-  account: ConnectedWalletAccount,
+  account: Account,
   contractAddress: string,
   contractMethods: ContractMethods,
 ): Contract & M {

--- a/app/src/ui/typography/Typography.tsx
+++ b/app/src/ui/typography/Typography.tsx
@@ -85,8 +85,11 @@ const Description: React.FC<TypographyProps> = ({ children, className, inline, .
   </p>
 );
 
-const MiniDescription: React.FC<TypographyProps> = ({ children, className, flat }) => (
-  <p className={clsx(styles["typography__mini-description"], className, { [styles.typography__flat]: flat })}>
+const MiniDescription: React.FC<TypographyProps> = ({ children, className, flat, ...props }) => (
+  <p
+    className={clsx(styles["typography__mini-description"], className, { [styles.typography__flat]: flat })}
+    {...props}
+  >
     {children}
   </p>
 );

--- a/app/src/ui/wallet-selector/WalletSelector.module.scss
+++ b/app/src/ui/wallet-selector/WalletSelector.module.scss
@@ -6,6 +6,32 @@
   align-items: center;
   height: $navbar-height;
 
+  &__icon {
+    &--connected {
+      color: var(--color-white);
+    }
+  }
+
+  &__icon-connected {
+    &--wrapper {
+      @extend .z-depth-1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      width: 18px;
+      height: 18px;
+      margin-top: -5px;
+      border-radius: 50%;
+      background-color: var(--color-status-success);
+    }
+
+    &--icon {
+      font-weight: bold;
+      color: var(--color-white);
+    }
+  }
+
   &__widget {
     position: absolute;
     top: $navbar-height;

--- a/app/src/ui/wallet-selector/WalletSelector.module.scss.d.ts
+++ b/app/src/ui/wallet-selector/WalletSelector.module.scss.d.ts
@@ -8,6 +8,9 @@ export type Styles = {
   "wallet-selector__chain-network-dropdowns--networks-list": string;
   "wallet-selector__chain-network-dropdowns--networks-list-card": string;
   "wallet-selector__connect": string;
+  "wallet-selector__icon--connected": string;
+  "wallet-selector__icon-connected--icon": string;
+  "wallet-selector__icon-connected--wrapper": string;
   "wallet-selector__widget": string;
   "wallet-selector__widget--backdrop": string;
   "z-depth-0": string;

--- a/app/src/ui/wallet-selector/WalletSelector.tsx
+++ b/app/src/ui/wallet-selector/WalletSelector.tsx
@@ -7,6 +7,7 @@ import { Button } from "../button/Button";
 import { Card } from "../card/Card";
 import { ChevronIcon } from "../icons/ChevronIcon";
 import { Typography } from "../typography/Typography";
+import { Icon } from "ui/icon/Icon";
 
 import styles from "./WalletSelector.module.scss";
 import { WalletSelectorProps } from "./WalletSelector.types";
@@ -33,8 +34,19 @@ export const WalletSelector: React.FC<WalletSelectorProps> = ({ className }) => 
 
   return (
     <div className={clsx(styles["wallet-selector"], className)}>
-      <Button size="xs" variant="outlined" onClick={handleOnConnectWalletClick}>
-        {wallet.isConnected ? `Connected: ${wallet.chain}` : "Connect Wallet"}
+      <Button
+        size="xs"
+        variant="outlined"
+        onClick={handleOnConnectWalletClick}
+        leftIcon={
+          wallet.isConnected && (
+            <div className={clsx(styles["wallet-selector__icon-connected--wrapper"])}>
+              <Icon name="icon-power-switch" className={clsx(styles["wallet-selector__icon-connected--icon"])} />
+            </div>
+          )
+        }
+      >
+        {wallet.isConnected ? `${wallet.chain}: ${wallet.network}` : "Connect Wallet"}
       </Button>
       {isWidgetVisible && (
         <>
@@ -86,7 +98,7 @@ export const WalletSelector: React.FC<WalletSelectorProps> = ({ className }) => 
               <Typography.Description>Balance</Typography.Description>
               <Typography.Text>{wallet.balance}</Typography.Text>
               <Typography.MiniDescription>
-                <Typography.Anchor href="#" target="_blank">
+                <Typography.Anchor href={`${wallet.explorer}/accounts/${wallet.address}`} target="_blank">
                   {wallet.isConnected && wallet.address}
                 </Typography.Anchor>
               </Typography.MiniDescription>


### PR DESCRIPTION
Displays current investors table in a modal. 

- and a few Date display improvements
- and a refactor of `useNearContract` to load info for guest users

<img width="1440" alt="Screen Shot 2022-01-25 at 09 44 13" src="https://user-images.githubusercontent.com/4053518/151009484-24ee49d8-91b2-490c-8476-10a9b0529fb8.png">


Closes #12 