### PR TITLE
feat(PropertyDetails): version 2 layout

### DIFF
--- a/app/src/app/home/home/Home2.module.scss
+++ b/app/src/app/home/home/Home2.module.scss
@@ -1,5 +1,6 @@
 @import "src/theme/base";
 @import "src/theme/button/primary";
+@import "src/theme/button/button-outline";
 
 .home {
   @include withNavbar;
@@ -107,5 +108,18 @@
 
   &__section {
     display: block;
+  }
+
+  &__property-card--cta {
+    @extend .button-outline;
+    display: block;
+    width: 100%;
+    padding: 9px 24px;
+    text-align: center;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }

--- a/app/src/app/home/home/Home2.module.scss.d.ts
+++ b/app/src/app/home/home/Home2.module.scss.d.ts
@@ -6,6 +6,14 @@ export type Styles = {
   button_primary_invert: string;
   button_primary_large: string;
   button_primary_medium: string;
+  "button-outline": string;
+  "button-outline__icon": string;
+  "button-outline_inverse": string;
+  "button-outline_inverse-thin": string;
+  "button-outline_large": string;
+  "button-outline_medium": string;
+  "button-outline--large": string;
+  "button-outline--medium": string;
   home: string;
   "home__featured-assets": string;
   "home__featured-assets--cards": string;
@@ -17,6 +25,7 @@ export type Styles = {
   "home__intro--linear-gradient": string;
   "home__intro--text-block": string;
   "home__powered-by": string;
+  "home__property-card--cta": string;
   home__section: string;
   "home__what-is": string;
   "home__what-is--row": string;

--- a/app/src/app/home/home/Home2.tsx
+++ b/app/src/app/home/home/Home2.tsx
@@ -9,12 +9,14 @@ import { Footer } from "ui/footer/Footer";
 import { WalletSelectorNavbar2 } from "ui/wallet-selector-navbar/WalletSelectorNavbar2";
 import { Button } from "ui/button/Button";
 import { PropertyCard } from "app/properties-index/property-card/PropertyCard";
+import { useRoutes } from "hooks/useRoutes/useRoutes";
 
 import styles from "./Home2.module.scss";
 import { HomeProps } from "./Home.types";
 
 export const Home2: React.FC<HomeProps> = ({ className }) => {
   const { t } = useTranslation(["home", "common"]);
+  const routes = useRoutes();
 
   return (
     <>
@@ -67,7 +69,14 @@ export const Home2: React.FC<HomeProps> = ({ className }) => {
             <div className={styles["home__featured-assets--cards"]}>
               <Grid.Row>
                 <Grid.Col lg={4}>
-                  <PropertyCard />
+                  <PropertyCard
+                    minimal
+                    action={
+                      <Typography.Link href={routes.property("123")} className={styles["home__property-card--cta"]}>
+                        Buy Shares
+                      </Typography.Link>
+                    }
+                  />
                 </Grid.Col>
               </Grid.Row>
             </div>

--- a/app/src/app/properties-index/property-card/PropertyCard.module.scss
+++ b/app/src/app/properties-index/property-card/PropertyCard.module.scss
@@ -1,5 +1,4 @@
 @import "src/theme/base";
-@import "src/theme/button/button-outline";
 
 .property-card {
   display: block;
@@ -11,6 +10,15 @@
 
   &__description {
     color: var(--color-typography-text);
+  }
+
+  &__details {
+    width: 100%;
+    height: 180px;
+    padding: $space-default;
+    overflow-y: scroll;
+    color: var(--color-typography-text);
+    background-color: var(--color-background-contrast);
   }
 
   &__sold-by {
@@ -28,19 +36,6 @@
   &__category {
     display: block;
     text-align: right;
-  }
-
-  &__cta {
-    @extend .button-outline;
-    display: block;
-    width: 100%;
-    padding: 9px 24px;
-    text-align: center;
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: none;
-    }
   }
 
   :global {

--- a/app/src/app/properties-index/property-card/PropertyCard.tsx
+++ b/app/src/app/properties-index/property-card/PropertyCard.tsx
@@ -3,54 +3,65 @@ import clsx from "clsx";
 import { Card } from "ui/card/Card";
 import { Typography } from "ui/typography/Typography";
 import { Grid } from "ui/grid/Grid";
-import { useRoutes } from "hooks/useRoutes/useRoutes";
+import { HorizontalLine } from "ui/horizontal-line/HorizontalLine";
 
 import { PropertyCardProps } from "./PropertyCard.types";
 import styles from "./PropertyCard.module.scss";
 
-export const PropertyCard: React.FC<PropertyCardProps> = ({ className }) => {
-  const routes = useRoutes();
-
-  return (
-    <Card
-      shadow
-      backgroundImageUrl="https://bafybeid2lakmlzuifkf6nlgnyqf4vylzwlaxqlusm64rxtie33gw3x6qpq.ipfs.infura-ipfs.io/simon-lee-hbFKxsIqclc-unsplash.jpeg"
-      className={clsx(styles["property-card"], className)}
-    >
-      <Card.Content>
-        <Grid.Row>
-          <Grid.Col lg={9} xs={9}>
-            <Typography.Headline6 className={styles["property-card__title"]}>Asset Title</Typography.Headline6>
-            <Typography.Description flat className={styles["property-card__description"]}>
-              Own a share of La Bella Mona, 1948.
-            </Typography.Description>
-            <Typography.Description flat className={styles["property-card__sold-by"]}>
-              Sold by the National Museum of Italy, Milano.
-            </Typography.Description>
-          </Grid.Col>
-          <Grid.Col lg={3} xs={3}>
-            <Typography.Description flat className={styles["property-card__category"]}>
-              Art: Digital
-            </Typography.Description>
-          </Grid.Col>
-        </Grid.Row>
-        <hr />
-        <Grid.Row justify="between">
-          <Grid.Col>
-            <Typography.Text flat className={styles["property-card__price"]}>
-              897.8976 Ⓝ
-            </Typography.Text>
-            <Typography.MiniDescription flat className={styles["property-card__exchange-rate"]}>
-              USD 500, 890.00
-            </Typography.MiniDescription>
-          </Grid.Col>
-          <Grid.Col>
-            <Typography.Link href={routes.property("123")} className={styles["property-card__cta"]}>
-              Buy Shares
-            </Typography.Link>
-          </Grid.Col>
-        </Grid.Row>
-      </Card.Content>
-    </Card>
-  );
-};
+export const PropertyCard: React.FC<PropertyCardProps> = ({ className, action, minimal }) => (
+  <Card
+    shadow
+    backgroundImageUrl="https://bafybeid2lakmlzuifkf6nlgnyqf4vylzwlaxqlusm64rxtie33gw3x6qpq.ipfs.infura-ipfs.io/simon-lee-hbFKxsIqclc-unsplash.jpeg"
+    className={clsx(styles["property-card"], className)}
+  >
+    <Card.Content>
+      <Grid.Row>
+        <Grid.Col lg={9} xs={9}>
+          <Typography.Headline6 className={styles["property-card__title"]}>Asset Title</Typography.Headline6>
+          <Typography.Description flat className={styles["property-card__description"]}>
+            Own a share of La Bella Mona, 1948.
+          </Typography.Description>
+          <Typography.Description flat className={styles["property-card__sold-by"]}>
+            Sold by the National Museum of Italy, Milano.
+          </Typography.Description>
+        </Grid.Col>
+        <Grid.Col lg={3} xs={3}>
+          <Typography.Description flat className={styles["property-card__category"]}>
+            Art: Digital
+          </Typography.Description>
+        </Grid.Col>
+      </Grid.Row>
+    </Card.Content>
+    {!minimal && (
+      <div className={styles["property-card__details"]}>
+        <Typography.Text>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Optio, distinctio. Dolore magni repudiandae porro?
+          Aperiam porro ipsa incidunt voluptatem excepturi accusamus quia corrupti, maxime dolor, temporibus, cum
+          consectetur necessitatibus recusandae.
+        </Typography.Text>
+        <Typography.Text>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Optio, distinctio. Dolore magni repudiandae porro?
+          Aperiam porro ipsa incidunt voluptatem excepturi accusamus quia corrupti, maxime dolor, temporibus, cum
+          consectetur necessitatibus recusandae.
+        </Typography.Text>
+      </div>
+    )}
+    <HorizontalLine flat />
+    <Card.Content>
+      <Grid.Row justify="between" align="center">
+        <Grid.Col>
+          <Typography.MiniDescription flat className={styles["property-card__price"]}>
+            Price
+          </Typography.MiniDescription>
+          <Typography.Text flat className={styles["property-card__price"]}>
+            897.8976 Ⓝ
+          </Typography.Text>
+          <Typography.MiniDescription flat className={styles["property-card__exchange-rate"]}>
+            USD 500, 890.00
+          </Typography.MiniDescription>
+        </Grid.Col>
+        <Grid.Col>{action}</Grid.Col>
+      </Grid.Row>
+    </Card.Content>
+  </Card>
+);

--- a/app/src/app/property-details/PropertyDetails2.module.scss
+++ b/app/src/app/property-details/PropertyDetails2.module.scss
@@ -1,0 +1,28 @@
+@import "src/theme/base";
+
+.property-details {
+  position: relative;
+
+  &__main {
+    @include withNavbar(1.2);
+  }
+
+  &__card {
+    margin-bottom: $navbar-height;
+  }
+
+  &__left {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+  }
+
+  &__actions {
+    &--secondary {
+      display: flex;
+      justify-content: space-between;
+      padding: $space-default;
+    }
+  }
+}

--- a/app/src/app/property-details/PropertyDetails2.module.scss
+++ b/app/src/app/property-details/PropertyDetails2.module.scss
@@ -11,6 +11,13 @@
     margin-bottom: $navbar-height;
   }
 
+  &__row-reverse {
+    @include atLargeTablet {
+      flex-flow: initial;
+    }
+    flex-flow: column-reverse;
+  }
+
   &__left {
     display: flex;
     flex-direction: column;

--- a/app/src/app/property-details/PropertyDetails2.module.scss.d.ts
+++ b/app/src/app/property-details/PropertyDetails2.module.scss.d.ts
@@ -1,12 +1,9 @@
 export type Styles = {
-  "property-card": string;
-  "property-card__category": string;
-  "property-card__description": string;
-  "property-card__details": string;
-  "property-card__exchange-rate": string;
-  "property-card__price": string;
-  "property-card__sold-by": string;
-  "property-card__title": string;
+  "property-details": string;
+  "property-details__actions--secondary": string;
+  "property-details__card": string;
+  "property-details__left": string;
+  "property-details__main": string;
   "z-depth-0": string;
   "z-depth-1": string;
   "z-depth-1-half": string;

--- a/app/src/app/property-details/PropertyDetails2.module.scss.d.ts
+++ b/app/src/app/property-details/PropertyDetails2.module.scss.d.ts
@@ -4,6 +4,7 @@ export type Styles = {
   "property-details__card": string;
   "property-details__left": string;
   "property-details__main": string;
+  "property-details__row-reverse": string;
   "z-depth-0": string;
   "z-depth-1": string;
   "z-depth-1-half": string;

--- a/app/src/app/property-details/PropertyDetails2.tsx
+++ b/app/src/app/property-details/PropertyDetails2.tsx
@@ -1,0 +1,70 @@
+import clsx from "clsx";
+
+import { MainPanel } from "ui/mainpanel/MainPanel";
+import { Grid } from "ui/grid/Grid";
+import { Card } from "ui/card/Card";
+import { Footer } from "ui/footer/Footer";
+import { WalletSelectorNavbar2 } from "ui/wallet-selector-navbar/WalletSelectorNavbar2";
+import { Typography } from "ui/typography/Typography";
+import { Button } from "ui/button/Button";
+import { PropertyCard } from "app/properties-index/property-card/PropertyCard";
+
+import styles from "./PropertyDetails2.module.scss";
+import { PropertyDetailsProps } from "./PropertyDetails2.types";
+
+export const PropertyDetails2: React.FC<PropertyDetailsProps> = ({ className }) => (
+  <>
+    <WalletSelectorNavbar2 />
+    <div className={clsx(styles["property-details"], className)}>
+      <main className={styles["property-details__main"]}>
+        <MainPanel className={styles["property-details__main"]}>
+          <Grid.Container>
+            <Grid.Row>
+              <Grid.Col lg={10} offset={{ lg: 1 }}>
+                <Card shadow className={styles["property-details__card"]}>
+                  <Grid.Row nogutter>
+                    <Grid.Col lg={6}>
+                      <div className={styles["property-details__left"]}>
+                        <Card.Content>
+                          <Typography.Headline2>Do your own research</Typography.Headline2>
+                          <Typography.TextLead>
+                            NEAR Holdings is a decentralized application. The assets posted here were audited by our
+                            internal team, but there are still risks involded.
+                          </Typography.TextLead>
+                          <Typography.TextLead>Read carefully:</Typography.TextLead>
+                          <Typography.TextBold>What happens upon buying shares</Typography.TextBold>
+                          <Typography.Text>
+                            When you click on “Buy Shares”, you’ll be redirected to the NEAR Wallet page to make a
+                            transfer transaction.
+                          </Typography.Text>
+                        </Card.Content>
+                        <div className={styles["property-details__actions--secondary"]}>
+                          <Button color="secondary" variant="outlined">
+                            Back
+                          </Button>
+                          <Button color="secondary" variant="outlined">
+                            More
+                          </Button>
+                        </div>
+                      </div>
+                    </Grid.Col>
+                    <Grid.Col lg={6}>
+                      <PropertyCard
+                        action={
+                          <Button color="primary" fullWidth>
+                            Buy Shares
+                          </Button>
+                        }
+                      />
+                    </Grid.Col>
+                  </Grid.Row>
+                </Card>
+              </Grid.Col>
+            </Grid.Row>
+          </Grid.Container>
+        </MainPanel>
+      </main>
+    </div>
+    <Footer />
+  </>
+);

--- a/app/src/app/property-details/PropertyDetails2.tsx
+++ b/app/src/app/property-details/PropertyDetails2.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { useState } from "react";
 
 import { MainPanel } from "ui/mainpanel/MainPanel";
 import { Grid } from "ui/grid/Grid";
@@ -8,63 +9,75 @@ import { WalletSelectorNavbar2 } from "ui/wallet-selector-navbar/WalletSelectorN
 import { Typography } from "ui/typography/Typography";
 import { Button } from "ui/button/Button";
 import { PropertyCard } from "app/properties-index/property-card/PropertyCard";
+import { Modal } from "ui/modal/Modal";
 
 import styles from "./PropertyDetails2.module.scss";
 import { PropertyDetailsProps } from "./PropertyDetails2.types";
+import { InvestmentDetails2 } from "./investment-details/InvestmentDetails2";
 
-export const PropertyDetails2: React.FC<PropertyDetailsProps> = ({ className }) => (
-  <>
-    <WalletSelectorNavbar2 />
-    <div className={clsx(styles["property-details"], className)}>
-      <main className={styles["property-details__main"]}>
-        <MainPanel className={styles["property-details__main"]}>
-          <Grid.Container>
-            <Grid.Row>
-              <Grid.Col lg={10} offset={{ lg: 1 }}>
-                <Card shadow className={styles["property-details__card"]}>
-                  <Grid.Row nogutter>
-                    <Grid.Col lg={6}>
-                      <div className={styles["property-details__left"]}>
-                        <Card.Content>
-                          <Typography.Headline2>Do your own research</Typography.Headline2>
-                          <Typography.TextLead>
-                            NEAR Holdings is a decentralized application. The assets posted here were audited by our
-                            internal team, but there are still risks involded.
-                          </Typography.TextLead>
-                          <Typography.TextLead>Read carefully:</Typography.TextLead>
-                          <Typography.TextBold>What happens upon buying shares</Typography.TextBold>
-                          <Typography.Text>
-                            When you click on “Buy Shares”, you’ll be redirected to the NEAR Wallet page to make a
-                            transfer transaction.
-                          </Typography.Text>
-                        </Card.Content>
-                        <div className={styles["property-details__actions--secondary"]}>
-                          <Button color="secondary" variant="outlined">
-                            Back
-                          </Button>
-                          <Button color="secondary" variant="outlined">
-                            More
-                          </Button>
+export const PropertyDetails2: React.FC<PropertyDetailsProps> = ({ className }) => {
+  const [isInvestmentDetailsModalOpen, setIsInvestmentDetailsModalOpen] = useState(false);
+
+  return (
+    <>
+      <WalletSelectorNavbar2 />
+      <div className={clsx(styles["property-details"], className)}>
+        <main className={styles["property-details__main"]}>
+          <MainPanel className={styles["property-details__main"]}>
+            <Grid.Container>
+              <Grid.Row>
+                <Grid.Col lg={10} offset={{ lg: 1 }}>
+                  <Card shadow className={styles["property-details__card"]}>
+                    <Grid.Row nogutter>
+                      <Grid.Col lg={6}>
+                        <div className={styles["property-details__left"]}>
+                          <Card.Content>
+                            <Typography.Headline2>Do your own research</Typography.Headline2>
+                            <Typography.TextLead>
+                              NEAR Holdings is a decentralized application. The assets posted here were audited by our
+                              internal team, but there are still risks involded.
+                            </Typography.TextLead>
+                            <Typography.TextLead>Read carefully:</Typography.TextLead>
+                            <Typography.TextBold>What happens upon buying shares</Typography.TextBold>
+                            <Typography.Text>
+                              When you click on “Buy Shares”, you’ll be redirected to the NEAR Wallet page to make a
+                              transfer transaction.
+                            </Typography.Text>
+                          </Card.Content>
+                          <div className={styles["property-details__actions--secondary"]}>
+                            <Button color="secondary" variant="outlined">
+                              Back
+                            </Button>
+                          </div>
                         </div>
-                      </div>
-                    </Grid.Col>
-                    <Grid.Col lg={6}>
-                      <PropertyCard
-                        action={
-                          <Button color="primary" fullWidth>
-                            Buy Shares
-                          </Button>
-                        }
-                      />
-                    </Grid.Col>
-                  </Grid.Row>
-                </Card>
-              </Grid.Col>
-            </Grid.Row>
-          </Grid.Container>
-        </MainPanel>
-      </main>
-    </div>
-    <Footer />
-  </>
-);
+                      </Grid.Col>
+                      <Grid.Col lg={6}>
+                        <PropertyCard
+                          action={
+                            <Button color="primary" fullWidth onClick={() => setIsInvestmentDetailsModalOpen(true)}>
+                              Buy Shares
+                            </Button>
+                          }
+                        />
+                      </Grid.Col>
+                    </Grid.Row>
+                  </Card>
+                </Grid.Col>
+              </Grid.Row>
+            </Grid.Container>
+          </MainPanel>
+        </main>
+      </div>
+      <Footer />
+
+      {isInvestmentDetailsModalOpen && (
+        <Modal isOpened onClose={() => null} aria-labelledby="Withdrawal Conditions Modal Window">
+          <Modal.Header onClose={() => setIsInvestmentDetailsModalOpen(false)}>
+            <Typography.Headline3 flat>Investment Details</Typography.Headline3>
+          </Modal.Header>
+          <InvestmentDetails2 contractAddress="ce_98-2_gt.escrowfactory.nearholdings.testnet" />
+        </Modal>
+      )}
+    </>
+  );
+};

--- a/app/src/app/property-details/PropertyDetails2.tsx
+++ b/app/src/app/property-details/PropertyDetails2.tsx
@@ -28,7 +28,7 @@ export const PropertyDetails2: React.FC<PropertyDetailsProps> = ({ className }) 
               <Grid.Row>
                 <Grid.Col lg={10} offset={{ lg: 1 }}>
                   <Card shadow className={styles["property-details__card"]}>
-                    <Grid.Row nogutter>
+                    <Grid.Row nogutter className={styles["property-details__row-reverse"]}>
                       <Grid.Col lg={6}>
                         <div className={styles["property-details__left"]}>
                           <Card.Content>

--- a/app/src/app/property-details/PropertyDetails2.types.ts
+++ b/app/src/app/property-details/PropertyDetails2.types.ts
@@ -1,8 +1,6 @@
 import { ReactNode } from "react";
 
-export type PropertyCardProps = {
+export type PropertyDetailsProps = {
   children?: ReactNode;
   className?: string;
-  minimal?: boolean;
-  action: ReactNode;
 };

--- a/app/src/app/property-details/PropertyDetailsContainer.tsx
+++ b/app/src/app/property-details/PropertyDetailsContainer.tsx
@@ -1,32 +1,3 @@
-import { useGetPropertyBySlugQuery } from "api/codegen";
-import { useRouter } from "next/router";
+import { PropertyDetails2 } from "./PropertyDetails2";
 
-import { GenericLoader } from "ui/generic-loader/GenericLoader";
-
-import { PropertyDetails } from "./PropertyDetails";
-
-export const PropertyDetailsContainer = () => {
-  const router = useRouter();
-
-  const { propertySlug } = router.query;
-
-  const {
-    data: getPropertyBySlugQueryData,
-    error: getPropertyBySlugQueryError,
-    loading: isGetPropertySlugQueryLoading,
-  } = useGetPropertyBySlugQuery({ variables: { input: { slug: propertySlug as string } } });
-
-  if (isGetPropertySlugQueryLoading) {
-    return <GenericLoader />;
-  }
-
-  if (getPropertyBySlugQueryError || !getPropertyBySlugQueryData?.getPropertyBySlug?.content) {
-    // @TODO redirect to generic error page
-
-    return null;
-  }
-
-  const property = getPropertyBySlugQueryData.getPropertyBySlug;
-
-  return <PropertyDetails property={property} />;
-};
+export const PropertyDetailsContainer = () => <PropertyDetails2 />;

--- a/app/src/app/property-details/investment-details/InvestmentDetails2.tsx
+++ b/app/src/app/property-details/investment-details/InvestmentDetails2.tsx
@@ -1,0 +1,434 @@
+import React, { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+
+import { Card } from "ui/card/Card";
+import { Modal } from "ui/modal/Modal";
+import { Typography } from "ui/typography/Typography";
+import { Grid } from "ui/grid/Grid";
+import { useWalletSelectorContext } from "hooks/useWalletSelectorContext/useWalletSelectorContext";
+import { CircularProgress } from "ui/circular-progress/CircularProgress";
+import { Button } from "ui/button/Button";
+import { useNearContract } from "hooks/useNearContract/useNearContract";
+import near from "providers/near";
+import { ContractDepositFormProps } from "../contract-deposit-form/ContractDepositForm.types";
+import getCoinCurrentPrice from "providers/currency/getCoinCurrentPrice";
+import formatFiatCurrency from "providers/currency/formatFiatCurrency";
+import date from "providers/date";
+import { useToastContext } from "hooks/useToastContext/useToastContext";
+
+import styles from "./InvestmentDetails.module.scss";
+import {
+  ConditionalEscrowMethods,
+  ConditionalEscrowValues,
+  InvestmentDetailsProps,
+  OnSubmitDeposit,
+} from "./InvestmentDetails.types";
+
+const VIEW_METHODS = [
+  "deposits_of",
+  "get_deposits",
+  "get_total_funds",
+  "get_expiration_date",
+  "get_funding_amount_limit",
+  "get_unpaid_funding_amount",
+  "get_recipient_account_id",
+  "is_deposit_allowed",
+  "is_withdrawal_allowed",
+];
+
+const CHANGE_METHODS = ["deposit", "withdraw", "delegate_funds"];
+
+const ContractDepositForm = dynamic<ContractDepositFormProps>(
+  () => import("../contract-deposit-form/ContractDepositForm").then((mod) => mod.ContractDepositForm),
+  { ssr: false },
+);
+
+const getDefaultContractValues = (): ConditionalEscrowValues => ({
+  totalFunds: near.formatAccountBalance("0"),
+  fundingAmountLimit: near.formatAccountBalance("0"),
+  unpaidFundingAmount: near.formatAccountBalance("0"),
+  depositsOf: "0",
+  depositsOfPercentage: 0,
+  currentCoinPrice: 0,
+  priceEquivalence: 0,
+  totalFundedPercentage: 0,
+  expirationDate: date.toNanoseconds(date.now().toDate().getTime()),
+  recipientAccountId: "",
+  isDepositAllowed: false,
+  isWithdrawalAllowed: false,
+  deposits: [],
+});
+
+export const InvestmentDetails2: React.FC<InvestmentDetailsProps> = ({ contractAddress }) => {
+  const [isBuyOwnershipInfoModalOpen, setIsBuyOwnershipInfoModalOpen] = useState(false);
+  const [isCurrentInvestorsModalOpen, setIsCurrentInvestorsModalOpen] = useState(false);
+  const [isWithdrawalConditionsModalOpen, setIsWithdrawalConditionsModalOpen] = useState(false);
+  const [isWithdrawalLoading, setIsWithdrawalLoading] = useState(false);
+  const [values, setValues] = useState<ConditionalEscrowValues>(getDefaultContractValues());
+
+  const toast = useToastContext();
+
+  const wallet = useWalletSelectorContext();
+
+  const contract = useNearContract<ConditionalEscrowMethods>(wallet, contractAddress, {
+    viewMethods: VIEW_METHODS,
+    changeMethods: CHANGE_METHODS,
+  });
+
+  useEffect(() => {
+    if (!contract) {
+      setValues(getDefaultContractValues());
+
+      return;
+    }
+
+    const getConstantValues = async () => {
+      const getTotalFundsResponse = await contract!.get_total_funds();
+      const getFundingAmountLimitResponse = await contract!.get_funding_amount_limit();
+      const getUnpaidFundingAmountResponse = await contract!.get_unpaid_funding_amount();
+      const totalFundedPercentage =
+        (BigInt(getTotalFundsResponse) * BigInt(100)) / BigInt(getFundingAmountLimitResponse);
+
+      const isDepositAllowed = await contract!.is_deposit_allowed();
+      const isWithdrawalAllowed = await contract!.is_withdrawal_allowed();
+
+      const deposits = await contract!.get_deposits();
+      const expirationDate = await contract!.get_expiration_date();
+      const depositsOfResponse = await contract!.deposits_of({ payee: wallet.address ?? wallet.context.guest.address });
+      const depositsOfPercentage = (BigInt(depositsOfResponse) * BigInt(100)) / BigInt(getFundingAmountLimitResponse);
+
+      const currentCoinPrice = await getCoinCurrentPrice("near", "usd");
+      const priceEquivalence =
+        currentCoinPrice *
+        Number(near.formatAccountBalanceFlat(BigInt(getFundingAmountLimitResponse).toString()).replace(",", ""));
+
+      const recipientAccountId = await contract!.get_recipient_account_id();
+
+      setValues({
+        totalFunds: near.formatAccountBalance(BigInt(getTotalFundsResponse).toString()),
+        fundingAmountLimit: near.formatAccountBalance(BigInt(getFundingAmountLimitResponse).toString()),
+        unpaidFundingAmount: near.formatAccountBalance(BigInt(getUnpaidFundingAmountResponse).toString()),
+        depositsOf: BigInt(depositsOfResponse).toString(),
+        totalFundedPercentage: Number(totalFundedPercentage),
+        depositsOfPercentage: Number(depositsOfPercentage),
+        currentCoinPrice,
+        priceEquivalence,
+        deposits,
+        expirationDate,
+        isDepositAllowed,
+        isWithdrawalAllowed,
+        recipientAccountId,
+      });
+    };
+
+    getConstantValues();
+  }, [contract, wallet.address, wallet.context?.guest?.address]);
+
+  const onClickAuthorizeWallet = () => {
+    wallet.onClickConnect({
+      contractId: contractAddress,
+      methodNames: [...VIEW_METHODS, ...CHANGE_METHODS],
+    });
+  };
+
+  const onClickInvestNow = async () => {
+    setIsBuyOwnershipInfoModalOpen(true);
+  };
+
+  const onClickWithdraw = async () => {
+    if (!contract) {
+      toast.trigger({
+        variant: "error",
+        title: "No contract is loaded",
+        withTimeout: true,
+        children: <Typography.Text>Check your internet connection and try refreshing the page.</Typography.Text>,
+      });
+    }
+
+    try {
+      setIsWithdrawalLoading(true);
+      await contract!.withdraw();
+      setIsWithdrawalLoading(false);
+
+      // @TODO i18n
+      toast.trigger({
+        variant: "confirmation",
+        title: "Withdrawal successful",
+        withTimeout: true,
+        children: <Typography.Text>Your funds have been withdrawn to your wallet</Typography.Text>,
+      });
+    } catch {
+      // @TODO i18n
+      toast.trigger({
+        variant: "error",
+        title: "Withdrawal error",
+        withTimeout: false,
+        children: <Typography.Text>Your funds are safe, check your internet connection and try again.</Typography.Text>,
+      });
+    }
+  };
+
+  const onSubmitDeposit = async ({ amount }: OnSubmitDeposit) => {
+    if (!contract) {
+      toast.trigger({
+        variant: "error",
+        title: "No contract is loaded",
+        withTimeout: true,
+        children: <Typography.Text>Check your internet connection and try refreshing the page.</Typography.Text>,
+      });
+    }
+
+    try {
+      await contract!.deposit({}, undefined, near.parseNearAmount(amount));
+    } catch {
+      // @TODO i18n
+      toast.trigger({
+        variant: "error",
+        title: "Deposit error",
+        withTimeout: false,
+        children: <Typography.Text>Your funds are safe, check your internet connection and try again.</Typography.Text>,
+      });
+    }
+  };
+
+  const getActions = () => {
+    if (!wallet.isConnected) {
+      return (
+        <Button color="primary" onClick={onClickAuthorizeWallet}>
+          Authorize Wallet
+        </Button>
+      );
+    }
+
+    if (values.isDepositAllowed && !values.isWithdrawalAllowed) {
+      return (
+        <>
+          <Typography.Description flat>
+            {`Offer expires ${date.timeFromNow.calendar(date.fromNanoseconds(values.expirationDate!)).toLowerCase()}`}
+          </Typography.Description>
+          <Button color="primary" onClick={onClickInvestNow}>
+            Invest Now
+          </Button>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Typography.Description flat>
+          {`Offer expired ${date.timeFromNow.calendar(date.fromNanoseconds(values.expirationDate!)).toLowerCase()}`}
+        </Typography.Description>
+        <Button
+          color="primary"
+          onClick={onClickWithdraw}
+          isLoading={isWithdrawalLoading}
+          disabled={values.depositsOf === "0"}
+        >
+          Withdraw
+        </Button>
+      </>
+    );
+  };
+
+  return (
+    <>
+      <Card>
+        <Card.Content>
+          <div className={styles["investment-details__sold"]}>
+            <div className={styles["investment-details__circular-progress"]}>
+              <CircularProgress size={70} strokeWidth={5} percentage={values.totalFundedPercentage} />
+            </div>
+            <div className={styles["investment-details__sold-description"]}>
+              <Typography.Description>Funded</Typography.Description>
+              <Typography.Text flat>{values.totalFunds}</Typography.Text>
+              <Typography.MiniDescription>
+                {`${values.totalFundedPercentage}% of property price`} ·{" "}
+                {`${date.timeFromNow.asDefault(date.fromNanoseconds(values.expirationDate!)).toLowerCase()}`}
+              </Typography.MiniDescription>
+            </div>
+          </div>
+          <div className={styles["investment-details__price"]}>
+            <div className={styles["investment-details__price-heading"]}>
+              <Typography.TextBold className={styles["investment-details__price-heading-text"]} flat>
+                Price
+              </Typography.TextBold>
+            </div>
+            <div className={styles["investment-details__price-description"]}>
+              <Typography.TextBold flat>{values.fundingAmountLimit}</Typography.TextBold>
+              <Typography.MiniDescription>
+                {formatFiatCurrency(values.priceEquivalence!)} USD ·{" "}
+                <Typography.Anchor href="#">1 Ⓝ = {values.currentCoinPrice} USD</Typography.Anchor>
+              </Typography.MiniDescription>
+            </div>
+          </div>
+          <hr />
+          <Grid.Row>
+            <Grid.Col lg={6} xs={6}>
+              <Typography.TextBold flat># of NEAR wallets</Typography.TextBold>
+              <Typography.MiniDescription
+                onClick={() => setIsCurrentInvestorsModalOpen(true)}
+                className={styles["investment-details__clickable"]}
+              >
+                See current investors
+              </Typography.MiniDescription>
+            </Grid.Col>
+            <Grid.Col>
+              <Typography.Text>{values.deposits?.length}</Typography.Text>
+            </Grid.Col>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Col lg={6} xs={6}>
+              <Typography.TextBold flat>Your current deposit</Typography.TextBold>
+              <Typography.MiniDescription
+                onClick={() => setIsWithdrawalConditionsModalOpen(true)}
+                className={styles["investment-details__clickable"]}
+              >
+                See withdrawal conditions
+              </Typography.MiniDescription>
+            </Grid.Col>
+            <Grid.Col>
+              <Typography.Text flat>{near.formatAccountBalance(values.depositsOf)}</Typography.Text>
+              <Typography.MiniDescription>{`${values.depositsOfPercentage}% of property price`}</Typography.MiniDescription>
+            </Grid.Col>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Col lg={6} xs={6}>
+              <Typography.TextBold flat>Available balance</Typography.TextBold>
+              <Typography.MiniDescription>On wallet: {wallet.address}</Typography.MiniDescription>
+            </Grid.Col>
+            <Grid.Col>
+              <Typography.Text>{wallet.balance}</Typography.Text>
+            </Grid.Col>
+          </Grid.Row>
+          <Grid.Row nowrap>
+            <Grid.Col lg={6} xs={6}>
+              <Typography.TextBold flat>Escrow Contract</Typography.TextBold>
+              <Typography.MiniDescription>Your money is secured by the NEAR Protocol</Typography.MiniDescription>
+            </Grid.Col>
+            <Grid.Col>
+              <Typography.Text>
+                <Typography.Anchor href={`${wallet.explorer}/accounts/${contractAddress}`} truncate target="_blank">
+                  {contractAddress}
+                </Typography.Anchor>
+              </Typography.Text>
+            </Grid.Col>
+          </Grid.Row>
+        </Card.Content>
+        <Card.Actions>{getActions()}</Card.Actions>
+      </Card>
+
+      {isBuyOwnershipInfoModalOpen && (
+        <Modal isOpened onClose={() => null} aria-labelledby="Buy Ownership Modal Window">
+          <Modal.Header>
+            <Typography.Headline3 flat className={styles["investment-details__register-interest-modal--header"]}>
+              Buy Property Ownership
+            </Typography.Headline3>
+          </Modal.Header>
+          <Modal.Content>
+            <Typography.Text>
+              {`Buying NEAR Real Estate NFT properties' ownership is anonymous and as simple as transfering any amount
+                of NEAR to the Property Escrow Contract.`}
+            </Typography.Text>
+            <Typography.Text>
+              Your funds stay securely on-hold and can be withdrawn only if the expiration date is reached and the price
+              has not been totally funded.
+            </Typography.Text>
+            <hr />
+            <Typography.Headline4>FAQs</Typography.Headline4>
+            <Typography.Headline5>What happens if the property is totally funded?</Typography.Headline5>
+            <Typography.Text>
+              The funds will be transfered to a DAO where you will be a member. Your voting power in the DAO will be
+              proportional to your investment.
+            </Typography.Text>
+            <Typography.Headline5>How does voting power is calculated?</Typography.Headline5>
+            <Typography.Text>
+              If the property is totally funded before the expiration date, an equivalent amount of NEP-141 tokens will
+              be minted and you will be transfered the amount proportional to your investment. These tokens represent
+              your voting power in the DAO and you can trade them whenever you like. Their value represents the property
+              value.
+            </Typography.Text>
+            <Typography.Headline5>Who is the real world owner of the property?</Typography.Headline5>
+            <Typography.Text>This is up to each DAO council to decide.</Typography.Text>
+            <Typography.Headline5>
+              If the funds are in NEAR Tokens, how is the property purchased with Fiat currency?
+            </Typography.Headline5>
+            <Typography.Text>
+              Each DAO council can decide how to exchange the NEAT token mutual funds to a currency that the property
+              seller expects.
+            </Typography.Text>
+            <Typography.Headline5>Is there a minimum deposit amount that I can invest?</Typography.Headline5>
+            <Typography.Text>
+              No, but keep in mind that the voting power you will have in the DAO council will be proportional to the
+              investment relative to the property price.
+            </Typography.Text>
+            <hr />
+            <Typography.Headline4>Owner Entitlement Details</Typography.Headline4>
+            <hr />
+            <Typography.Headline4>Owner Obligations Details</Typography.Headline4>
+            <hr />
+            <Typography.Headline4>Risks</Typography.Headline4>
+          </Modal.Content>
+          <Modal.Actions>
+            <ContractDepositForm
+              isLoading={false}
+              onSubmit={(val) => onSubmitDeposit(val as OnSubmitDeposit)}
+              autoFocus
+              onCancel={() => setIsBuyOwnershipInfoModalOpen(false)}
+            />
+          </Modal.Actions>
+        </Modal>
+      )}
+
+      {isCurrentInvestorsModalOpen && (
+        <Modal isOpened onClose={() => null} aria-labelledby="Current Investors Modal Window">
+          <Modal.Header onClose={() => setIsCurrentInvestorsModalOpen(false)}>
+            <Typography.Headline3 flat className={styles["investment-details__register-interest-modal--header"]}>
+              Current Investors
+            </Typography.Headline3>
+          </Modal.Header>
+          <Modal.Content>
+            {values.deposits?.length &&
+              values.deposits?.map((deposit) => (
+                <Grid.Row key={deposit[0]}>
+                  <Grid.Col>
+                    <Typography.Text>{deposit[0]}</Typography.Text>
+                  </Grid.Col>
+                  <Grid.Col>
+                    <Typography.Text>{near.formatAccountBalance(BigInt(deposit[1]).toString())}</Typography.Text>
+                  </Grid.Col>
+                </Grid.Row>
+              ))}
+          </Modal.Content>
+        </Modal>
+      )}
+
+      {isWithdrawalConditionsModalOpen && (
+        <Modal isOpened onClose={() => null} aria-labelledby="Withdrawal Conditions Modal Window">
+          <Modal.Header onClose={() => setIsWithdrawalConditionsModalOpen(false)}>
+            <Typography.Headline3 flat className={styles["investment-details__register-interest-modal--header"]}>
+              Withdrawal Conditions
+            </Typography.Headline3>
+          </Modal.Header>
+          <Modal.Content>
+            <Typography.Text>
+              The ability to withdraw your funds is coded into the NEAR Smart Contract that holds the funds temporarily.
+              This contract has been audited to ensure the security of your funds.
+            </Typography.Text>
+            <Typography.Text>
+              {`For this contract, you'll be able to withdraw your funds ${date.timeFromNow
+                .calendar(date.fromNanoseconds(values.expirationDate!))
+                .toLowerCase()} AND if the property price has not been totally funded.`}
+            </Typography.Text>
+            <Typography.Anchor href="#" target="_blank">
+              See contract code
+            </Typography.Anchor>
+            <br />
+            <Typography.Anchor href="#" target="_blank">
+              See in explorer
+            </Typography.Anchor>
+          </Modal.Content>
+        </Modal>
+      )}
+    </>
+  );
+};

--- a/app/src/pages/p/[propertySlug].tsx
+++ b/app/src/pages/p/[propertySlug].tsx
@@ -18,7 +18,7 @@ export async function getStaticPaths() {
     paths: [
       { params: { propertySlug: "lot-40-in-exclusive-residential-complex-cafetales-de-santa-ana" }, locale: "en" },
       {
-        params: { propertySlug: "lote-7-en-cafetales-de-santa-ana-5-minutos-a-pie-de-antigua-guatemala-centro_en" },
+        params: { propertySlug: "123" },
         locale: "en",
       },
     ],

--- a/app/src/theme/globals.scss
+++ b/app/src/theme/globals.scss
@@ -176,9 +176,9 @@ body[data-theme="light"] {
   --color-button-primary-hover: var(--color-primary);
   --color-button-primary-hover-text: var(--color-white);
   --color-button-primary-disabled: var(--color-dark-5);
-  --color-button-secondary: var(--color-dark-8);
+  --color-button-secondary: var(--color-dark-4);
   --color-button-secondary-text: var(--color-dark-4);
-  --color-button-secondary-hover: var(--color-primary);
+  --color-button-secondary-hover: var(--color-black);
   --color-button-secondary-hover-text: var(--color-white);
 
   // Typography

--- a/app/src/ui/button/Button.module.scss
+++ b/app/src/ui/button/Button.module.scss
@@ -204,11 +204,13 @@ $HALF_LOADER_SIZE: 15px;
     }
 
     &.button--secondary {
+      border: none;
       background-color: transparent;
 
       &:active,
       &:hover,
       &:focus {
+        color: var(--color-button-secondary-text);
         background-color: transparent;
       }
 
@@ -341,8 +343,22 @@ $HALF_LOADER_SIZE: 15px;
       &:hover,
       &:focus {
         border-color: var(--color-button-secondary-hover);
-        color: var(--color-button-secondary-hover-text);
+        color: var(--color-button-secondary-text);
         background: var(--color-button-secondary-hover);
+      }
+
+      &[disabled] {
+        border-color: var(--color-dark-1);
+        color: var(--color-dark-1);
+        background-color: var(--color-white);
+
+        &:active,
+        &:hover,
+        &:focus {
+          border-color: var(--color-button-secondary-hover);
+          color: var(--color-button-secondary-text);
+          background: var(--color-button-secondary-hover);
+        }
       }
     }
 

--- a/app/src/ui/card/Card.module.scss
+++ b/app/src/ui/card/Card.module.scss
@@ -1,6 +1,9 @@
 @import "src/theme/base";
 
 .card {
+  border-radius: $border-radius;
+  background-color: var(--color-background);
+
   &__shadow {
     @extend .z-depth-1;
   }
@@ -10,15 +13,19 @@
   }
 
   &__actions {
+    display: flex;
+    justify-content: flex-end;
+    border-top: 1px solid var(--color-background-contrast);
+    padding: $space-default;
+
     > button,
     > p {
+      align-self: center;
+
       &:nth-child(n + 2) {
         margin-left: $space-default;
       }
     }
-    display: flex;
-    border-top: 1px solid var(--color-background-contrast);
-    padding: $space-default;
   }
 
   &__background-image {
@@ -33,6 +40,4 @@
   &__link {
     cursor: pointer;
   }
-  border-radius: $border-radius;
-  background-color: var(--color-background);
 }

--- a/app/src/ui/footer/Footer.module.scss
+++ b/app/src/ui/footer/Footer.module.scss
@@ -53,7 +53,6 @@
     &--description {
       @include atLargeTablet {
         margin-bottom: 0;
-        text-align: right;
       }
       margin-bottom: $space-l;
       color: var(--color-white);

--- a/app/src/ui/horizontal-line/HorizontalLine.module.scss
+++ b/app/src/ui/horizontal-line/HorizontalLine.module.scss
@@ -1,0 +1,10 @@
+@import "src/theme/base";
+
+.horizontal-line {
+  display: block;
+
+  &__flat {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/app/src/ui/horizontal-line/HorizontalLine.module.scss.d.ts
+++ b/app/src/ui/horizontal-line/HorizontalLine.module.scss.d.ts
@@ -1,12 +1,6 @@
 export type Styles = {
-  "property-card": string;
-  "property-card__category": string;
-  "property-card__description": string;
-  "property-card__details": string;
-  "property-card__exchange-rate": string;
-  "property-card__price": string;
-  "property-card__sold-by": string;
-  "property-card__title": string;
+  "horizontal-line": string;
+  "horizontal-line__flat": string;
   "z-depth-0": string;
   "z-depth-1": string;
   "z-depth-1-half": string;

--- a/app/src/ui/horizontal-line/HorizontalLine.test.tsx
+++ b/app/src/ui/horizontal-line/HorizontalLine.test.tsx
@@ -1,0 +1,13 @@
+import { screen, render } from "tests";
+
+import { HorizontalLine } from "./HorizontalLine";
+
+describe("HorizontalLine", () => {
+  it("renders children correctly", () => {
+    render(<HorizontalLine>HorizontalLine</HorizontalLine>);
+
+    const element = screen.getByText("HorizontalLine");
+
+    expect(element).toBeInTheDocument();
+  });
+});

--- a/app/src/ui/horizontal-line/HorizontalLine.tsx
+++ b/app/src/ui/horizontal-line/HorizontalLine.tsx
@@ -1,0 +1,8 @@
+import clsx from "clsx";
+
+import { HorizontalLineProps } from "./HorizontalLine.types";
+import styles from "./HorizontalLine.module.scss";
+
+export const HorizontalLine: React.FC<HorizontalLineProps> = ({ className, flat }) => (
+  <hr className={clsx(styles["horizontal-line"], className, { [styles["horizontal-line__flat"]]: flat })} />
+);

--- a/app/src/ui/horizontal-line/HorizontalLine.types.ts
+++ b/app/src/ui/horizontal-line/HorizontalLine.types.ts
@@ -1,8 +1,7 @@
 import { ReactNode } from "react";
 
-export type PropertyCardProps = {
+export type HorizontalLineProps = {
   children?: ReactNode;
   className?: string;
-  minimal?: boolean;
-  action: ReactNode;
+  flat?: boolean;
 };

--- a/app/src/ui/modal/Modal.module.scss
+++ b/app/src/ui/modal/Modal.module.scss
@@ -94,6 +94,11 @@
     border-bottom: $border-divider;
     padding: $space-ml;
     color: var(--color-typography-text);
+
+    &--on-close {
+      display: flex;
+      justify-content: flex-end;
+    }
   }
 
   &__content {

--- a/app/src/ui/modal/Modal.module.scss
+++ b/app/src/ui/modal/Modal.module.scss
@@ -1,4 +1,4 @@
-@import "/src/theme/_base";
+@import "src/theme/_base";
 
 @mixin fullscreen {
   position: absolute;

--- a/app/src/ui/modal/Modal.module.scss.d.ts
+++ b/app/src/ui/modal/Modal.module.scss.d.ts
@@ -5,6 +5,7 @@ export type Styles = {
   "modal__close-button--float": string;
   modal__content: string;
   modal__header: string;
+  "modal__header--on-close": string;
   modal__overlay: string;
   modal__wrapper: string;
   "modal__wrapper--fullscreen": string;
@@ -17,6 +18,13 @@ export type Styles = {
   "modal--enter-active": string;
   "modal--exit": string;
   "modal--exit-active": string;
+  "z-depth-0": string;
+  "z-depth-1": string;
+  "z-depth-1-half": string;
+  "z-depth-2": string;
+  "z-depth-3": string;
+  "z-depth-4": string;
+  "z-depth-5": string;
 };
 
 export type ClassNames = keyof Styles;

--- a/app/src/ui/modal/Modal.tsx
+++ b/app/src/ui/modal/Modal.tsx
@@ -126,8 +126,10 @@ Modal.Header = ({ children, className, onClose, ...props }: ModalHeaderProps) =>
     return (
       <div className={clsx(styles.modal__header, className)} {...props}>
         <Grid.Row justify="between" align="center">
-          <Grid.Col lg={8}>{children}</Grid.Col>
-          <Grid.Col lg={4}>
+          <Grid.Col lg={8} xs={8}>
+            {children}
+          </Grid.Col>
+          <Grid.Col lg={4} xs={4}>
             <div className={styles["modal__header--on-close"]}>
               <Button size="xs" onClick={onClose} color="secondary" variant="text">
                 Close

--- a/app/src/ui/modal/Modal.tsx
+++ b/app/src/ui/modal/Modal.tsx
@@ -3,12 +3,20 @@ import React, { KeyboardEvent, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { CSSTransition } from "react-transition-group";
 
+import { Button } from "ui/button/Button";
+import { Grid } from "ui/grid/Grid";
 import { IconButton } from "../iconButton/IconButton";
 import { CloseIcon } from "../icons/CloseIcon";
 
 import { CloseButton } from "./CloseButton/CloseButton";
 import styles from "./Modal.module.scss";
-import { ModalFullscreenProps, ModalItemProps, ModalNotFullscreenProps, ModalProps } from "./Modal.types";
+import {
+  ModalFullscreenProps,
+  ModalHeaderProps,
+  ModalItemProps,
+  ModalNotFullscreenProps,
+  ModalProps,
+} from "./Modal.types";
 
 export const MODAL_ANIMATION_TIME = 300;
 
@@ -113,9 +121,30 @@ export const Modal = ({
   return createPortal(modalElement, document.querySelector("#modal-root")!);
 };
 
-Modal.Header = ({ className, ...props }: ModalItemProps) => (
-  <div className={clsx(styles.modal__header, className)} {...props} />
-);
+Modal.Header = ({ children, className, onClose, ...props }: ModalHeaderProps) => {
+  if (onClose) {
+    return (
+      <div className={clsx(styles.modal__header, className)} {...props}>
+        <Grid.Row justify="between" align="center">
+          <Grid.Col lg={8}>{children}</Grid.Col>
+          <Grid.Col lg={4}>
+            <div className={styles["modal__header--on-close"]}>
+              <Button size="xs" onClick={onClose} color="secondary" variant="text">
+                Close
+              </Button>
+            </div>
+          </Grid.Col>
+        </Grid.Row>
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx(styles.modal__header, className)} {...props}>
+      {children}
+    </div>
+  );
+};
 
 Modal.Content = ({ className, ...props }: ModalItemProps) => (
   <div className={clsx(styles.modal__content, className)} {...props} />

--- a/app/src/ui/modal/Modal.types.ts
+++ b/app/src/ui/modal/Modal.types.ts
@@ -26,3 +26,7 @@ export type ModalNotFullscreenProps = ModalCommonProps & {
 export type ModalProps = ModalFullscreenProps | ModalNotFullscreenProps;
 
 export type ModalItemProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+
+export type ModalHeaderProps = ModalItemProps & {
+  onClose?: () => void;
+};


### PR DESCRIPTION
This PR includes a layout update: 

<img width="1440" alt="Screen Shot 2022-02-08 at 20 31 35" src="https://user-images.githubusercontent.com/4053518/153110684-8e5e812f-867f-44be-be98-6ac4a8fd9c31.png">

it should continue to display the investment details component fetching the actual contract data from `testnet`
