### PR TITLE
feat: uploads typeform images to IPFS

### DIFF
--- a/app/src/app/properties-index/property-card/PropertyCard.tsx
+++ b/app/src/app/properties-index/property-card/PropertyCard.tsx
@@ -4,14 +4,30 @@ import { Card } from "ui/card/Card";
 import { Typography } from "ui/typography/Typography";
 import { Grid } from "ui/grid/Grid";
 import { HorizontalLine } from "ui/horizontal-line/HorizontalLine";
+import ipfs from "providers/ipfs";
+import date from "providers/date";
 
 import { PropertyCardProps } from "./PropertyCard.types";
 import styles from "./PropertyCard.module.scss";
 
+export const DEFAULT_PROPERTY_CARD_PROPS = {
+  title: "Loading",
+  price: 0,
+  shortDescription: "Loading",
+  longDescription: "Loading",
+  category: "Loading",
+  expirationDate: date.now().format(),
+  media: {
+    featuredImageUrl:
+      "bafybeictugtlj7ixe5u2ylavxzhm7dvs6nqzgykv7pgrvlfsxccbfai6pm/near-holdings-icon-loading-template.jpg",
+    ipfsURL: "ipfs://",
+  },
+};
+
 export const PropertyCard: React.FC<PropertyCardProps> = ({ className, action, minimal, property }) => (
   <Card
     shadow
-    backgroundImageUrl={property.media.featuredImageUrl}
+    backgroundImageUrl={ipfs.asHttpsURL(property.media.featuredImageUrl)}
     className={clsx(styles["property-card"], className)}
   >
     <Card.Content>

--- a/app/src/app/property-details/PropertyDetailsContainer.tsx
+++ b/app/src/app/property-details/PropertyDetailsContainer.tsx
@@ -1,4 +1,3 @@
-import { PropertyCard } from "api/codegen";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
@@ -14,6 +13,8 @@ import {
 import { ConditionalEscrowMethods, ConditionalEscrowValues } from "providers/near/contract/conditional-escrow.types";
 import { Typography } from "ui/typography/Typography";
 import ipfs from "providers/ipfs";
+import { DEFAULT_PROPERTY_CARD_PROPS } from "app/properties-index/property-card/PropertyCard";
+import { PropertyCardProps } from "app/properties-index/property-card/PropertyCard.types";
 
 import { PropertyDetails2 } from "./PropertyDetails2";
 
@@ -30,15 +31,7 @@ async function getPropertyFromMetadataUrl(url: string) {
 export const PropertyDetailsContainer = () => {
   const [contractData, setContractData] = useState<ConditionalEscrowValues>(getDefaultContractValues());
   const [isContractDataLoading, setIsContractDataLoading] = useState(false);
-  const [property, setProperty] = useState<PropertyCard>({
-    title: "Loading",
-    price: 0,
-    shortDescription: "Loading",
-    longDescription: "Loading",
-    category: "Loading",
-    expirationDate: "MM/DD/YYYY",
-    media: { featuredImageUrl: "/property-details/near-holdings-icon-loading-template.jpg", ipfsURL: "ipfs://" },
-  });
+  const [property, setProperty] = useState<PropertyCardProps["property"]>(DEFAULT_PROPERTY_CARD_PROPS);
 
   const router = useRouter();
   const wallet = useWalletSelectorContext();

--- a/app/src/app/property-preview/PropertyPreview.tsx
+++ b/app/src/app/property-preview/PropertyPreview.tsx
@@ -10,7 +10,7 @@ import { MainPanel } from "ui/mainpanel/MainPanel";
 import { Grid } from "ui/grid/Grid";
 import { Card } from "ui/card/Card";
 import { Typography } from "ui/typography/Typography";
-import { PropertyCard } from "app/properties-index/property-card/PropertyCard";
+import { DEFAULT_PROPERTY_CARD_PROPS, PropertyCard } from "app/properties-index/property-card/PropertyCard";
 import { Button } from "ui/button/Button";
 import { useWalletSelectorContext } from "hooks/useWalletSelectorContext/useWalletSelectorContext";
 import { Modal } from "ui/modal/Modal";
@@ -26,15 +26,7 @@ import styles from "./PropertyPreview.module.scss";
 
 export const PropertyPreview: React.FC<PropertyPreviewProps> = ({ className, responseId }) => {
   const [isAuthorizeWalletModalOpen, setIsAuthorizeWalletModalOpen] = useState(false);
-  const [property, setProperty] = useState<PropertyCardProps["property"]>({
-    title: "Loading",
-    price: 0,
-    shortDescription: "Loading",
-    longDescription: "Loading",
-    category: "Loading",
-    expirationDate: "MM/DD/YYYY",
-    media: { featuredImageUrl: "/property-details/near-holdings-icon-loading-template.jpg", ipfsURL: "ipfs://" },
-  });
+  const [property, setProperty] = useState<PropertyCardProps["property"]>(DEFAULT_PROPERTY_CARD_PROPS);
 
   const wallet = useWalletSelectorContext();
   const toast = useToastContext();

--- a/app/src/providers/ipfs/upload.ts
+++ b/app/src/providers/ipfs/upload.ts
@@ -45,14 +45,13 @@ async function addFileToIPFS(
   };
 }
 
-export default async (content: string, name: string): Promise<IpfsResponse | null> => {
+export default async (content: Buffer, name: string): Promise<IpfsResponse | null> => {
   try {
-    const jsonFileName = `${name}.json`;
-    const result = await addFileToIPFS(Buffer.from(content), { path: jsonFileName });
+    const result = await addFileToIPFS(content, { path: name });
 
     return {
       ...result,
-      name: jsonFileName,
+      name,
     };
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
In production, returning more than 4MB of data from a GQL endpoint throws a Vercel error.
This fixes that.